### PR TITLE
Make opamp write "O" instead of "gnd" nodes

### DIFF
--- a/qucs/qucs/components/opamp.cpp
+++ b/qucs/qucs/components/opamp.cpp
@@ -77,8 +77,11 @@ Element* OpAmp::info(QString& Name, char* &BitmapFile, bool getNewOne)
 QString OpAmp::spice_netlist(bool isXyce)
 {
     QString in_p = Ports.at(0)->Connection->Name;
+    if (in_p=="gnd") in_p="0";
     QString in_m = Ports.at(1)->Connection->Name;
+    if (in_m=="gnd") in_m="0";
     QString out = Ports.at(2)->Connection->Name;
+    if (out=="gnd") out="0";
 
     QString G = spicecompat::normalize_value(Props.at(0)->Value);
     QString Vmax = spicecompat::normalize_value(Props.at(1)->Value);


### PR DESCRIPTION
When opamp writes out a spice netlist, write "0" whenever the node name
is "gnd".

Xyce does not recognize "gnd" as an alias for ground (neither does
SPICE3F5, on which Xyce's netlist language was based).  It does have a
netlist option intended to make it recognize that alias (and others),
but it has a bug that makes it not work when the alias is used inside an
expression, as it is when Qucs-S generates the ideal opamp model as a B
source.

Since most other devices go through pains to convert "gnd" in their node
names into "0", I inserted similar code into the opamp.cpp
"spice_netlist" function.

With this simple change, schematics created by qucs-sactivefilter now can run
in Xyce (when the "ac simulation" object is replaced by an appropriate
"xyce script" object).  It was an attempt to run one of these filter schematics that led both to realizing that there was a bug in Xyce and that the op-amp code was missing this ground-name-substitution code that other devices have.