### PR TITLE
Force settings save when Default Simulator dialog "apply" button is clicked.

### DIFF
--- a/qucs/qucs/extsimkernels/simsettingsdialog.cpp
+++ b/qucs/qucs/extsimkernels/simsettingsdialog.cpp
@@ -146,7 +146,8 @@ void SimSettingsDialog::slotApply()
     }
     QucsSettings.DefaultSimulator = cbxSimulator->currentIndex();
     accept();
-}
+    saveApplSettings();
+  }
 
 void SimSettingsDialog::slotCancel()
 {


### PR DESCRIPTION
If a user modifies settings in the Simulator->Select default simulator dialog and clicks "apply,"  the settings are not saved until the user also opens the File->Application Settings dialog and clicks "Ok" there.  This confused me for a long time, and is a source of confusion for our potential users of Qucs-s as a Xyce schematic capture tool.

That's because there is a missing call to saveApplSettings in the slotApply slot in qucs/qucs/extsimkernels/simsettingsdialog.cpp

Adding this call makes the code behave as a user would expect: the persistent storage is created upon clicking "Apply" if it doesn't already exist, and is updated correctly if it did already exist.