### PR TITLE
Fix for the warnings at graph.cpp and diagramdialog.cpp

### DIFF
--- a/qucs/qucs/diagrams/diagramdialog.cpp
+++ b/qucs/qucs/diagrams/diagramdialog.cpp
@@ -1639,10 +1639,9 @@ void DiagramDialog::addvar(QString a)
     m = GraphList->findItems(Var2, Qt::MatchExactly);
     l = Var2.indexOf(a,0,Qt::CaseSensitive);
 
-    if( l != -1 && Var2.size() == (l + a.size()) && !m.size()>0)//Var2.size == (l + a.size()) in case of voltage (.v) to don't let pass a variable like (name.var)
+    if( l != -1 && Var2.size() == (l + a.size()) && !(m.size()>0))//Var2.size == (l + a.size()) in case of voltage (.v) to don't let pass a variable like (name.var)
     {
-      QTableWidgetItem* I;
-      slotTakeVar(I);
+      slotTakeVar(NULL);//In the case of the phasor diagram, the table ChooseVars is not used. Instead of that, the graph is put in the list bu using Var2.
     }
 
   } while(i > 0);

--- a/qucs/qucs/diagrams/graph.cpp
+++ b/qucs/qucs/diagrams/graph.cpp
@@ -305,7 +305,7 @@ int Graph::getSelectedP(int x, int y)
           yn = d1 * float(x) + b1;
         }
       }
-      if(((f1 >= f3) && (xn >= f3)  && (xn <= f1)) || (f3 >= f1) && (xn >= f1)  && (xn <= f3))
+      if(((f1 >= f3) && (xn >= f3)  && (xn <= f1)) || ((f3 >= f1) && (xn >= f1)  && (xn <= f3)))
         if(((f2 >= f4) && (yn >= f4) && (yn <= f2)) || ((f4 >= f2) && (yn >= f2) && (yn <= f4)))
           if((y >= int(yn) - 5) && (y <= int(yn) + 5) && (x >= int(xn) - 5) && (x <= int(xn) + 5))
             return 1;


### PR DESCRIPTION
This is a fix for the warnings that arises at compiling graph.cpp and
diagramdialog.cpp

In the case of the phasor diagrams, the graphs to be displayed are added
using Var2 instead of using the ChooseVars table. This means that it is
not necessary to pass a QTableWidgetItem object to 'slotTakeVar()' as
the graph selection is already managed there